### PR TITLE
feat(helm): add webhook support and update e2e tests to use Helm

### DIFF
--- a/helm/supabase-operator/templates/_helpers.tpl
+++ b/helm/supabase-operator/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Webhook service name
+*/}}
+{{- define "supabase-operator.webhookServiceName" -}}
+{{- printf "%s-webhook" (include "supabase-operator.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Webhook certificate secret name
+*/}}
+{{- define "supabase-operator.webhookCertSecret" -}}
+{{- printf "%s-webhook-cert" (include "supabase-operator.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/helm/supabase-operator/templates/deployment.yaml
+++ b/helm/supabase-operator/templates/deployment.yaml
@@ -56,6 +56,12 @@ spec:
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           {{- end }}
+          {{- if .Values.webhook.enabled }}
+          ports:
+            - containerPort: {{ .Values.webhook.targetPort }}
+              name: webhook-server
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -70,14 +76,31 @@ spec:
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.extraVolumeMounts }}
+          {{- $extraMounts := .Values.extraVolumeMounts }}
+          {{- if or .Values.webhook.enabled (and $extraMounts (not (empty $extraMounts))) }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
+            {{- if .Values.webhook.enabled }}
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: webhook-cert
+              readOnly: true
+            {{- end }}
+            {{- if $extraMounts }}
+            {{- toYaml $extraMounts | nindent 12 }}
+            {{- end }}
           {{- end }}
       terminationGracePeriodSeconds: 10
-      {{- with .Values.extraVolumes }}
+      {{- $extraVolumes := .Values.extraVolumes }}
+      {{- if or .Values.webhook.enabled (and $extraVolumes (not (empty $extraVolumes))) }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.webhook.enabled }}
+        - name: webhook-cert
+          secret:
+            secretName: {{ include "supabase-operator.webhookCertSecret" . }}
+            defaultMode: 420
+        {{- end }}
+        {{- if $extraVolumes }}
+        {{- toYaml $extraVolumes | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/supabase-operator/templates/webhook-certmanager.yaml
+++ b/helm/supabase-operator/templates/webhook-certmanager.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "supabase-operator.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "supabase-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "supabase-operator.webhookCertSecret" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "supabase-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "supabase-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc
+    - {{ include "supabase-operator.webhookServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "supabase-operator.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "supabase-operator.webhookCertSecret" . }}
+{{- end }}

--- a/helm/supabase-operator/templates/webhook-configurations.yaml
+++ b/helm/supabase-operator/templates/webhook-configurations.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "supabase-operator.fullname" . }}-mutating-webhook
+  labels:
+    {{- include "supabase-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "supabase-operator.webhookCertSecret" .) }}
+webhooks:
+  - name: msupabaseproject.kb.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "supabase-operator.webhookServiceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-supabase-strrl-dev-v1alpha1-supabaseproject
+    rules:
+      - apiGroups: ["supabase.strrl.dev"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["supabaseprojects"]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "supabase-operator.fullname" . }}-validating-webhook
+  labels:
+    {{- include "supabase-operator.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace (include "supabase-operator.webhookCertSecret" .) }}
+webhooks:
+  - name: vsupabaseproject.kb.io
+    admissionReviewVersions: ["v1"]
+    failurePolicy: {{ .Values.webhook.failurePolicy }}
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "supabase-operator.webhookServiceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: /validate-supabase-strrl-dev-v1alpha1-supabaseproject
+    rules:
+      - apiGroups: ["supabase.strrl.dev"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["supabaseprojects"]
+{{- end }}

--- a/helm/supabase-operator/templates/webhook-service.yaml
+++ b/helm/supabase-operator/templates/webhook-service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supabase-operator.webhookServiceName" . }}
+  labels:
+    {{- include "supabase-operator.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "supabase-operator.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: webhook
+      port: {{ .Values.webhook.servicePort }}
+      targetPort: {{ .Values.webhook.targetPort }}
+      protocol: TCP
+{{- end }}

--- a/helm/supabase-operator/values.yaml
+++ b/helm/supabase-operator/values.yaml
@@ -66,3 +66,9 @@ tolerations: []
 affinity: {}
 
 topologySpreadConstraints: []
+
+webhook:
+  enabled: true
+  servicePort: 443
+  targetPort: 9443
+  failurePolicy: Fail


### PR DESCRIPTION
- Add webhook templates: service, cert-manager issuer/certificate, mutating/validating webhook configurations
- Update deployment to mount webhook certs and expose webhook port
- Add webhook configuration values (enabled, ports, failurePolicy)
- Migrate e2e tests from make deploy to helm upgrade --install
- Add dynamic image tagging based on git SHA in e2e suite